### PR TITLE
ci: use GITHUB_TOKEN for checkout@v3

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -16,10 +16,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-        token: ${{ secrets.GH_PAT }}
     - name: ${{ matrix.step }}
       env:
-        GH_PAT: ${{ secrets.GH_PAT }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: |
         yarn install --immutable | grep -v 'YN0013'

--- a/packages/dev/scripts/alt-research-ci-ghact-build.mjs
+++ b/packages/dev/scripts/alt-research-ci-ghact-build.mjs
@@ -10,7 +10,7 @@ import gitSetup from './gitSetup.mjs';
 
 console.log('$ alt-research-ci-ghact-build', process.argv.slice(2).join(' '));
 
-const repo = `https://${process.env.GH_PAT}@github.com/${process.env.GITHUB_REPOSITORY}.git`;
+const repo = `https://x-access-token:${process.env.GITHUB_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}.git`;
 
 const argv = yargs(process.argv.slice(2))
   .options({


### PR DESCRIPTION
## Description
This PR replaces `GH_PAT` with `GITHUB_TOKEN` such that we can fix the 403 error in https://github.com/alt-research/dev/runs/6021976252?check_suite_focus=true#step:3:155

## References
- https://github.com/marketplace/actions/checkout#checkout-multiple-repos-private
- https://docs.github.com/en/github-ae@latest/actions/security-guides/automatic-token-authentication
- https://github.com/polkadot-js/dev/commit/2162ad6096bed9558f380a9cee65c0730e41c4fc